### PR TITLE
Removed the So Make It logo from email base theme

### DIFF
--- a/app/views/emails/base.jade
+++ b/app/views/emails/base.jade
@@ -2,5 +2,4 @@ doctype html
 html
   head
   body
-    img(src="https://members.somakeit.org.uk/img/header.png", alt="So Make It")
     block content


### PR DESCRIPTION
Removing the logo will allow for a new feature of being able to upload and set your own logo in members-area

@benjie mind approving this? If it's not too much trouble. 